### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["staging", "main"]
 
+permissions:
+  contents: read
+
 jobs:
   create-deployment-artifacts:
     name: Create Deployment artifacts
@@ -46,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-deployment-artifacts]
     environment: ${{ contains(github.ref_name, 'main') && 'production' || 'staging'}}
+    permissions:
+      contents: read
+      secrets: read
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -89,6 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-deployment-artifacts, prepare-release-on-server]
     environment: ${{ contains(github.ref_name, 'main') && 'production' || 'staging'}}
+    permissions:
+      contents: read
     steps:
       - name: Activate release
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
Potential fix for [https://github.com/pbs-ie/postalbibleschool.ie/security/code-scanning/1](https://github.com/pbs-ie/postalbibleschool.ie/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, such as checking out the repository, uploading artifacts, and interacting with secrets, the `contents: read` permission is sufficient for most steps. Additional permissions, such as `packages: read` or `id-token: write`, will only be added if explicitly required by the workflow.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If any job requires additional permissions, a job-specific `permissions` block will be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
