### PR TITLE
Empty classrooms check added to table

### DIFF
--- a/resources/ts/Components/Tables/SunscoolSchoolsTable.tsx
+++ b/resources/ts/Components/Tables/SunscoolSchoolsTable.tsx
@@ -27,11 +27,13 @@ export default function SunscoolSchoolsTable({ schools }: { schools: SunscoolSch
                 return (
                     <div key={'actions' + row.id} className="flex items-center">
                         <>
-                            <IconHoverSpan>
-                                <ButtonLink dataTest="school_open_icon" hierarchy="transparent" size="xsmall" href={route("settings.sunscool.classroom", { schoolId: row.original.id, classroomId: row.original.classes[0].id })}><span className="flex flex-col items-center">
-                                    <FolderOpenIcon className="w-6 h-6" key={row.id} />Open
-                                </span></ButtonLink>
-                            </IconHoverSpan>
+                            {row.original.classes?.length > 0 &&
+                                <IconHoverSpan>
+                                    <ButtonLink dataTest="school_open_icon" hierarchy="transparent" size="xsmall" href={route("settings.sunscool.classroom", { schoolId: row.original.id, classroomId: row.original.classes[0].id })}><span className="flex flex-col items-center">
+                                        <FolderOpenIcon className="w-6 h-6" key={row.id} />Open
+                                    </span></ButtonLink>
+                                </IconHoverSpan>
+                            }
                         </>
                     </div>
                 )


### PR DESCRIPTION
## Proposed changes

Sunscool Table was throwing an error for schools with empty classes array. An array length check has been added to still load the remaining schools.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
